### PR TITLE
Fix carousel bug (closes #5)

### DIFF
--- a/src/community_site/static/js/script.js
+++ b/src/community_site/static/js/script.js
@@ -54,16 +54,11 @@ function getHome() {
                        <a href="https://discord.gg/Zp3sKp" class="btn btn-outline-light btn-lg">Join Now</a>
                    </div>
                </div>
-               <div class="carousel-inner">
-                   <div class="carousel-item">
-                       <img src="static/img/img-2.jpg" alt="">
-                   </div>
-                   
-                   <div class="carousel-inner">
-                       <div class="carousel-item">
-                           <img src="static/img/img-3.jpeg" alt="">
-                       </div>
-                   </div>
+               <div class="carousel-item">
+                   <img src="static/img/img-2.jpg" alt="">
+               </div>
+               <div class="carousel-item">
+                   <img src="static/img/img-3.jpeg" alt="">
                </div>
            </div>
        </div>


### PR DESCRIPTION
The bug was caused by attempting to declare multiple levels of "carousel-inner" classes within each other. A single "carousel-inner" in each carousel should contain only items of class "carousel-item".

This should close https://github.com/neilchauhan2/Community-Website/issues/5